### PR TITLE
Adding CI for base img + candyfloss build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,25 @@
 name: Build
 
-on: [ push ]
+on: [ push, workflow_dispatch ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  BASE_IMAGE_NAME: ${{ github.repository }}-base
 
 jobs:
-  build:
+  build-app:
     runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
+    
+      # General setup 
+      
       - name: Checkout sources
         uses: actions/checkout@v4
 
@@ -15,7 +29,79 @@ jobs:
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
+      # Build app for base image
+      
       - name: Build with Gradle
         run: ./gradlew build
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Extract metadata (tags, labels) for Docker - base
+        id: meta-base
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}
+          tags: |
+            # set latest tag for master branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{raw}}
+            
+      - name: Build and push Docker base image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker/base
+          push: true
+          tags: ${{ steps.meta-base.outputs.tags }}
+          labels: ${{ steps.meta-base.outputs.labels }}
+          
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      # Building of the final image using Jib
+ 
+      - name: Extract metadata (tags, labels) for Docker - final build
+        id: meta-final
+        uses: docker/metadata-action@v5
+        with:
+          tags: |
+            # set latest tag for master branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=ref,event=branch
+            type=ref,event=pr,enable=${{ github.event == 'pull_request' }}
+            type=semver,pattern={{raw}}
+
+      - name: Format tags (swap newlines with commas)
+        run: |
+          echo "FINAL_TAGS=$(echo $DOCKER_METADATA_OUTPUT_TAGS | sed 's/ /,/g')" >> $GITHUB_ENV
+
+      - name: Build and push cosmos candyfloss docker final image
+        run: >-
+          ./gradlew :candyfloss:jib 
+          -Djib.from.image=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_NAME }}:${{ env.DOCKER_METADATA_OUTPUT_VERSION }}
+          -Djib.to.image=${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          -Djib.to.tags=${{ env.FINAL_TAGS }}
+          -Djib.container.user="1001:1001"
+      - name: Gather generated image digest for attestation
+        run: |
+          echo "FINAL_IMG_DIGEST=$(cat ./candyfloss/build/jib-image.digest)" >> $GITHUB_ENV
+          
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ env.FINAL_IMG_DIGEST }}
+          push-to-registry: true


### PR DESCRIPTION
Adding the CI elements to : 
- Build the base image & generate attestation
- Build the final candyfloss image (from base) & generate attestation

Triggered on tag/release/push for latest, or manually using a workflow run.