### PR TITLE
Enable compatibility of comments in pipeline config

### DIFF
--- a/candyfloss/src/main/java/com/swisscom/daisy/cosmos/candyfloss/transformers/FromJsonTransformer.java
+++ b/candyfloss/src/main/java/com/swisscom/daisy/cosmos/candyfloss/transformers/FromJsonTransformer.java
@@ -1,5 +1,7 @@
 package com.swisscom.daisy.cosmos.candyfloss.transformers;
 
+import static com.swisscom.daisy.cosmos.candyfloss.transformations.jolt.CustomFunctions.factory;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,8 +17,6 @@ import java.util.Map;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.processor.ProcessorContext;
-
-import static com.swisscom.daisy.cosmos.candyfloss.transformations.jolt.CustomFunctions.factory;
 
 public class FromJsonTransformer
     implements Transformer<String, String, KeyValue<String, ValueErrorMessage<DocumentContext>>> {

--- a/candyfloss/src/main/java/com/swisscom/daisy/cosmos/candyfloss/transformers/FromJsonTransformer.java
+++ b/candyfloss/src/main/java/com/swisscom/daisy/cosmos/candyfloss/transformers/FromJsonTransformer.java
@@ -16,6 +16,8 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.processor.ProcessorContext;
 
+import static com.swisscom.daisy.cosmos.candyfloss.transformations.jolt.CustomFunctions.factory;
+
 public class FromJsonTransformer
     implements Transformer<String, String, KeyValue<String, ValueErrorMessage<DocumentContext>>> {
   private static final Configuration configuration =
@@ -34,7 +36,7 @@ public class FromJsonTransformer
           .register(Metrics.globalRegistry);
 
   private final ObjectMapper objectMapper =
-      new ObjectMapper().configure(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS, true);
+      new ObjectMapper(factory).configure(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS, true);
   private ProcessorContext context;
 
   @Override

--- a/candyfloss/src/main/resources/pipeline/oc-interface.json
+++ b/candyfloss/src/main/resources/pipeline/oc-interface.json
@@ -1,4 +1,7 @@
 {
+  /*
+  Note that this config is comprehensive and contains "match", "transform" and "normalization"
+  */
   "match": {
     "or": [
       {
@@ -417,7 +420,7 @@
   "normalizeCounters": {
     "timestamp-extractor": {
       "jsonpath": "$.msg_timestamp",
-      "timestamp-type": "EpochMilli"
+      "timestamp-type": "EpochMilli"  // Note: most timestamp is in milliseconds format
     },
     "counters": [
       {
@@ -438,7 +441,7 @@
         ],
         "type": "u64",
         "value": {
-          "jsonpath": "$.in_broadcast_pkts"
+          "jsonpath": "$.in_broadcast_pkts" // Important: Metric must be numerical so that can be "normalized".
         }
       },
       {

--- a/candyfloss/src/main/resources/pre-transform.dev.json
+++ b/candyfloss/src/main/resources/pre-transform.dev.json
@@ -1,4 +1,7 @@
 [
+  /*
+  This transformation makes sure (door keeper) that we only process valid messages.
+  */
   {
     "operation": "shift",
     "spec": {

--- a/candyfloss/src/test/resources/avro-input/pipeline.json
+++ b/candyfloss/src/test/resources/avro-input/pipeline.json
@@ -3,6 +3,7 @@
   "match": {},
   "transform": [
     {
+      // Note: this transformation is for avro input
       "operation": "shift",
       "spec": {
         "event": "[].transformed_event"

--- a/candyfloss/src/test/resources/counter-normalization/normal/output1.json
+++ b/candyfloss/src/test/resources/counter-normalization/normal/output1.json
@@ -24,7 +24,7 @@
   "timestamp": 1647244767278,
   "name": "TenGigE0/0/0/0",
   "state": {
-    "u64-counter": null,
+    "u64-counter": null, // no previous counter to be compared, therefore, it's null
     "u32-counter": null,
     "u32-value": 4294967295,
     "u64-value": 18446744073709551615

--- a/candyfloss/src/test/resources/deployment/discard/discard-valid-json/01-discard.json
+++ b/candyfloss/src/test/resources/deployment/discard/discard-valid-json/01-discard.json
@@ -1,4 +1,5 @@
 {
+  // this will be in the discard topic
   "event_type": "log",
   "seq": 1835,
   "timestamp": "2022-09-05 09:47:25.588797",

--- a/candyfloss/src/test/resources/deployment/oc-interface/aggregate/01-input.json
+++ b/candyfloss/src/test/resources/deployment/oc-interface/aggregate/01-input.json
@@ -9,6 +9,6 @@
     "pkey": "HCC"
   },
   "telemetry_data": "{\"node_id_str\":\"hcc-zbl1315-r-pe-60\",\"subscription_id_str\":\"DAISY-SUBSCRIPTION\",\"encoding_path\":\"openconfig-interfaces:interfaces\",\"collection_id\":\"456710\",\"collection_start_time\":\"1662364045589\",\"msg_timestamp\":\"1662364045598\",\"data_json\":[{\"timestamp\":\"1662364045596\",\"content\":{\"interface\":{\"name\":\"Bundle-Ether100\",\"openconfig-if-aggregate:aggregation\":{\"state\":{\"lag-type\":\"LACP\",\"min-links\":1,\"lag-speed\":10000000,\"member\":[\"TenGigE0/0/0/1\"]}}}}},{\"timestamp\":\"1662364045596\",\"content\":{\"interface\":{\"name\":\"TenGigE0/0/0/1\",\"openconfig-if-ethernet:ethernet\":{\"state\":{\"openconfig-if-aggregate:aggregate-id\":\"Bundle-Ether100\"}}}}},{\"timestamp\":\"1662364045596\",\"content\":{\"interface\":{\"name\":\"Bundle-Ether200\",\"openconfig-if-aggregate:aggregation\":{\"state\":{\"lag-type\":\"LACP\",\"min-links\":1,\"lag-speed\":10000000,\"member\":[\"TenGigE0/0/0/2\"]}}}}},{\"timestamp\":\"1662364045596\",\"content\":{\"interface\":{\"name\":\"TenGigE0/0/0/2\",\"openconfig-if-ethernet:ethernet\":{\"state\":{\"openconfig-if-aggregate:aggregate-id\":\"Bundle-Ether200\"}}}}}],\"collection_end_time\":\"1662364045598\"}",
-  "serialization": "json_string",
+  "serialization": "json_string",  // this leaf should be here so that it assures message will go into the pipeline
   "writer_id": "daisy64sttcpjson-left01c 20220829-0 (30874711)"
 }

--- a/json-transformation/src/main/java/com/swisscom/daisy/cosmos/candyfloss/transformations/jolt/CustomFunctions.java
+++ b/json-transformation/src/main/java/com/swisscom/daisy/cosmos/candyfloss/transformations/jolt/CustomFunctions.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CustomFunctions {
   public static final JsonFactory factory =
-          JsonFactory.builder().enable(JsonReadFeature.ALLOW_JAVA_COMMENTS).build();
+      JsonFactory.builder().enable(JsonReadFeature.ALLOW_JAVA_COMMENTS).build();
 
   public static final class jsonStringToJson extends Function.SingleFunction<Object> {
     private static final Logger logger = LoggerFactory.getLogger(CustomFunctions.class);

--- a/json-transformation/src/main/java/com/swisscom/daisy/cosmos/candyfloss/transformations/jolt/CustomFunctions.java
+++ b/json-transformation/src/main/java/com/swisscom/daisy/cosmos/candyfloss/transformations/jolt/CustomFunctions.java
@@ -3,6 +3,8 @@ package com.swisscom.daisy.cosmos.candyfloss.transformations.jolt;
 import com.bazaarvoice.jolt.common.Optional;
 import com.bazaarvoice.jolt.modifier.function.Function;
 import com.bazaarvoice.jolt.modifier.function.Objects;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
@@ -13,10 +15,13 @@ import org.slf4j.LoggerFactory;
  * Custom functions to be used in Jolt transformations.
  */
 public class CustomFunctions {
+  public static final JsonFactory factory =
+          JsonFactory.builder().enable(JsonReadFeature.ALLOW_JAVA_COMMENTS).build();
+
   public static final class jsonStringToJson extends Function.SingleFunction<Object> {
     private static final Logger logger = LoggerFactory.getLogger(CustomFunctions.class);
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper(factory);
 
     @Override
     protected Optional<Object> applySingle(Object arg) {

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -8,6 +8,7 @@ version "0.1.0"
 
 dependencies {
     implementation libs.jackson.databind
+    implementation project(':json-transformation')
     testImplementation libs.junit.jupiter.api
     testRuntimeOnly libs.junit.jupiter.engine
 }

--- a/test-utils/src/main/java/com/swisscom/daisy/cosmos/candyfloss/testutils/JsonUtil.java
+++ b/test-utils/src/main/java/com/swisscom/daisy/cosmos/candyfloss/testutils/JsonUtil.java
@@ -1,5 +1,7 @@
 package com.swisscom.daisy.cosmos.candyfloss.testutils;
 
+import static com.swisscom.daisy.cosmos.candyfloss.transformations.jolt.CustomFunctions.factory;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -9,8 +11,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import static com.swisscom.daisy.cosmos.candyfloss.transformations.jolt.CustomFunctions.factory;
 
 /***
  * Json helper functions to read test fixtures

--- a/test-utils/src/main/java/com/swisscom/daisy/cosmos/candyfloss/testutils/JsonUtil.java
+++ b/test-utils/src/main/java/com/swisscom/daisy/cosmos/candyfloss/testutils/JsonUtil.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static com.swisscom.daisy.cosmos.candyfloss.transformations.jolt.CustomFunctions.factory;
+
 /***
  * Json helper functions to read test fixtures
  */
@@ -30,7 +32,7 @@ public class JsonUtil {
       throw new NullPointerException("inputStream is null");
     }
     var jsonString = JsonUtil.readFromInputStream(inputStream);
-    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapper = new ObjectMapper(factory);
     return objectMapper.readValue(jsonString, Map.class);
   }
 
@@ -43,7 +45,7 @@ public class JsonUtil {
 
   public static List<Map<String, Object>> readJsonArray(InputStream inputStream)
       throws IOException {
-    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapper = new ObjectMapper(factory);
     List<Map<String, Object>> result = new ArrayList<>();
     var jsonString = JsonUtil.readFromInputStream(inputStream);
     var iterator = objectMapper.readerFor(Map.class).readValues(jsonString);


### PR DESCRIPTION
In this PR, it allowed all json pipeilne config, input/output unittest, being able to add comments in it.

Currently, it recognise comments as java-compatible form - e.g. either "/* */" or "//"
