### PR TITLE
Bugfix/disable unnecessary logging

### DIFF
--- a/candyfloss/src/main/java/com/swisscom/daisy/cosmos/candyfloss/processors/CounterNormalizationProcessor.java
+++ b/candyfloss/src/main/java/com/swisscom/daisy/cosmos/candyfloss/processors/CounterNormalizationProcessor.java
@@ -160,11 +160,11 @@ public class CounterNormalizationProcessor
 
     if (logger.isDebugEnabled()) {
       logger.debug(
-              "Extracted counter key '{}' and value '{}' with timestamp '{}' from message: '{}'",
-              counterKey,
-              counterValue,
-              timestamp,
-              flattenedMessage.getValue().json());
+          "Extracted counter key '{}' and value '{}' with timestamp '{}' from message: '{}'",
+          counterKey,
+          counterValue,
+          timestamp,
+          flattenedMessage.getValue().json());
     }
 
     // Find the old value of the counter in the store state.
@@ -174,11 +174,11 @@ public class CounterNormalizationProcessor
     if (savedCounterState != null) {
       if (logger.isDebugEnabled()) {
         logger.debug(
-                "Value in stateStore for counter key '{}' is '{}' with timestamp '{}' from message: '{}'",
-                counterKey,
-                savedCounterState.value(),
-                savedCounterState.timestamp(),
-                flattenedMessage.getValue().json());
+            "Value in stateStore for counter key '{}' is '{}' with timestamp '{}' from message: '{}'",
+            counterKey,
+            savedCounterState.value(),
+            savedCounterState.timestamp(),
+            flattenedMessage.getValue().json());
       }
       if (timestamp.toEpochMilli() < savedCounterState.timestamp()) {
         logger.warn(
@@ -198,11 +198,11 @@ public class CounterNormalizationProcessor
     }
     if (logger.isDebugEnabled()) {
       logger.debug(
-              "Saved counter key '{}' and value '{}' with timestamp '{}' for message: '{}'",
-              counterKey,
-              counterValue,
-              timestamp,
-              flattenedMessage.getValue().json());
+          "Saved counter key '{}' and value '{}' with timestamp '{}' for message: '{}'",
+          counterKey,
+          counterValue,
+          timestamp,
+          flattenedMessage.getValue().json());
     }
 
     // Normalize the counter

--- a/candyfloss/src/main/java/com/swisscom/daisy/cosmos/candyfloss/processors/CounterNormalizationProcessor.java
+++ b/candyfloss/src/main/java/com/swisscom/daisy/cosmos/candyfloss/processors/CounterNormalizationProcessor.java
@@ -157,23 +157,29 @@ public class CounterNormalizationProcessor
     if (counterValue == null) {
       return;
     }
-    logger.debug(
-        "Extracted counter key '{}' and value '{}' with timestamp '{}' from message: '{}'",
-        counterKey,
-        counterValue,
-        timestamp,
-        flattenedMessage.getValue().json());
+
+    if (logger.isDebugEnabled()) {
+      logger.debug(
+              "Extracted counter key '{}' and value '{}' with timestamp '{}' from message: '{}'",
+              counterKey,
+              counterValue,
+              timestamp,
+              flattenedMessage.getValue().json());
+    }
+
     // Find the old value of the counter in the store state.
     // if no value exists then the same counter value is returned
     ValueAndTimestamp<Bytes> savedCounterState =
         getCounterSavedState(counterKey, counterValue, timestamp);
     if (savedCounterState != null) {
-      logger.debug(
-          "Value in stateStore for counter key '{}' is '{}' with timestamp '{}' from message: '{}'",
-          counterKey,
-          savedCounterState.value(),
-          savedCounterState.timestamp(),
-          flattenedMessage.getValue().json());
+      if (logger.isDebugEnabled()) {
+        logger.debug(
+                "Value in stateStore for counter key '{}' is '{}' with timestamp '{}' from message: '{}'",
+                counterKey,
+                savedCounterState.value(),
+                savedCounterState.timestamp(),
+                flattenedMessage.getValue().json());
+      }
       if (timestamp.toEpochMilli() < savedCounterState.timestamp()) {
         logger.warn(
             "Received a message with a timestamp {} older than saved in the counter store {}. Message: {}",
@@ -190,12 +196,14 @@ public class CounterNormalizationProcessor
                 timestamp.toEpochMilli()));
       }
     }
-    logger.debug(
-        "Saved counter key '{}' and value '{}' with timestamp '{}' for message: '{}'",
-        counterKey,
-        counterValue,
-        timestamp,
-        flattenedMessage.getValue().json());
+    if (logger.isDebugEnabled()) {
+      logger.debug(
+              "Saved counter key '{}' and value '{}' with timestamp '{}' for message: '{}'",
+              counterKey,
+              counterValue,
+              timestamp,
+              flattenedMessage.getValue().json());
+    }
 
     // Normalize the counter
     BigInteger normalizedValue = null;


### PR DESCRIPTION
We found that the `.json()` is called anyway even logging level is INFO. Therefore adding additional check for it.

Many thanks for discovering the issue and fix proposal @ahassany 