### PR TITLE
update candyfloss jackson-databind resolutionStrategy

### DIFF
--- a/candyfloss/build.gradle
+++ b/candyfloss/build.gradle
@@ -19,6 +19,7 @@ configurations.configureEach {
     resolutionStrategy {
         force "com.fasterxml.jackson.core:jackson-core:2.14.2"
         force "com.fasterxml.jackson.core:jackson-annotations:2.14.2"
+        force "com.fasterxml.jackson.core:jackson-databind:2.14.2"
         force "org.apache.commons:commons-compress:1.22"
     }
 }


### PR DESCRIPTION
this PR update resolutionStrategy to force `jackson-databind` to be the same version with other "com.fasterxml.jackson.core" utilities.

all with `2.14.2`.