### PR TITLE
Bugfix/remove statestore large ts inconsistency

### DIFF
--- a/candyfloss/src/main/java/com/swisscom/daisy/cosmos/candyfloss/CandyflossKStreamsApplication.java
+++ b/candyfloss/src/main/java/com/swisscom/daisy/cosmos/candyfloss/CandyflossKStreamsApplication.java
@@ -221,6 +221,7 @@ public class CandyflossKStreamsApplication {
                     new CounterNormalizationProcessor(
                         config.getPipeline(),
                         config.getStateStoreName(),
+                        config.getStateStoreCutoffTime(),
                         config.getMaxCounterCacheAge(),
                         config.getIntCounterWrapAroundLimit(),
                         config.getLongCounterWrapAroundLimit(),

--- a/candyfloss/src/main/java/com/swisscom/daisy/cosmos/candyfloss/config/JsonKStreamApplicationConfig.java
+++ b/candyfloss/src/main/java/com/swisscom/daisy/cosmos/candyfloss/config/JsonKStreamApplicationConfig.java
@@ -32,6 +32,7 @@ public class JsonKStreamApplicationConfig {
   private final String discardTopicName;
   private final String dlqTopicName;
   private final String stateStoreName;
+  private final long stateStoreCutoffTime;
   private final long maxCounterCacheAge;
   private final int intCounterWrapAroundLimit;
   private final long longCounterWrapAroundLimit;
@@ -58,6 +59,8 @@ public class JsonKStreamApplicationConfig {
     }
     final String discardTopicName = config.getConfig("kstream").getString("discard.topic.name");
     final String dlqTopicName = config.getConfig("kstream").getString("dlq.topic.name");
+    final long stateStoreCutoffTime =
+        config.getConfig("kstream").getLong("normalization.statestore.cutoff.time.ms");
     final String stateStoreName = config.getConfig("kstream").getString("state.store.name");
     final long maxCounterCacheAge =
         config.getConfig("kstream").getLong("state.store.max.counter.cache.age");
@@ -90,6 +93,7 @@ public class JsonKStreamApplicationConfig {
         discardTopicName,
         dlqTopicName,
         stateStoreName,
+        stateStoreCutoffTime,
         maxCounterCacheAge,
         intCounterWrapAroundLimit,
         longCounterWrapAroundLimit,

--- a/candyfloss/src/main/resources/application.dev.conf
+++ b/candyfloss/src/main/resources/application.dev.conf
@@ -18,6 +18,7 @@ kstream {
   input.topic.name = dev.device-json-raw-input
   discard.topic.name = dev.candyfloss-processing-discard # All messages that didn't match any step in the pipeline
   dlq.topic.name = dev.candyfloss-processing--dlq # Messages that encountered a Java exception during the processing
+  normalization.statestore.cutoff.time.ms = 1800000 # 30 minutes
   state.store.name = dev.candyfloss-counters-store # Kafka state store name to save the counter values
   state.store.max.counter.cache.age = 900000 // 15 minutes
   state.store.int.counter.wrap.limit = 10000

--- a/candyfloss/src/main/resources/application.ietf.dev.conf
+++ b/candyfloss/src/main/resources/application.ietf.dev.conf
@@ -20,6 +20,7 @@ kstream {
   input.topic.name = daisy.dev.device-json-raw
   discard.topic.name = daisy.dev.candyfloss-discard
   dlq.topic.name = daisy.dev.candyfloss-dlq
+  normalization.statestore.cutoff.time.ms = 1800000 # 30 minutes
   state.store.name = candyfloss-counters-store
   state.store.max.counter.cache.age = 900000 // 15 minutes
   state.store.int.counter.wrap.limit = 10000

--- a/candyfloss/src/main/resources/application.prod.conf
+++ b/candyfloss/src/main/resources/application.prod.conf
@@ -18,6 +18,7 @@ kstream {
   input.topic.name = prod.device-json-raw-input
   discard.topic.name = prod.candyfloss-processing-discard # All messages that didn't match any step in the pipeline
   dlq.topic.name = prod.candyfloss-processing-dlq # Messages that encountered a Java exception during the processing
+  normalization.statestore.cutoff.time.ms = 1800000 # 30 minutes
   state.store.name = prod.candyfloss-counters-store # Kafka state store name to save the counter values
   state.store.max.counter.cache.age = 900000 // 15 minutes
   state.store.int.counter.wrap.limit = 10000

--- a/candyfloss/src/main/resources/application.test.conf
+++ b/candyfloss/src/main/resources/application.test.conf
@@ -19,6 +19,7 @@ kstream {
   discard.topic.name = test.candyfloss-processing-discard # All messages that didn't match any step in the pipeline
   dlq.topic.name = test.candyfloss-processing-dlq # Messages that encountered a Java exception during the processing
   state.store.name = test.candyfloss-counters-store # Kafka state store name to save the counter values
+  normalization.statestore.cutoff.time.ms = 1800000 # 30 minutes
   state.store.max.counter.cache.age = 900000 // 15 minutes
   state.store.int.counter.wrap.limit = 10000
   state.store.long.counter.wrap.limit = 10000000

--- a/candyfloss/src/test/resources/avro-input/application.conf
+++ b/candyfloss/src/test/resources/avro-input/application.conf
@@ -16,6 +16,7 @@ kstream {
   discard.topic.name = daisy.dev.avro-input-discard
   dlq.topic.name =daisy.dev.avro-input-dlq
   state.store.name = daisy.dev.avro-input-store
+  normalization.statestore.cutoff.time.ms = 1800000 # 30 minutes
   state.store.max.counter.cache.age = 1000
   state.store.int.counter.wrap.limit = 10000
   state.store.long.counter.wrap.limit = 10000000

--- a/candyfloss/src/test/resources/counter-normalization/application-milli.conf
+++ b/candyfloss/src/test/resources/counter-normalization/application-milli.conf
@@ -13,6 +13,7 @@ kstream {
   input.topic.name = daisy.prod.device-json-raw
   discard.topic.name = daisy.dev.device-json-flat
   dlq.topic.name = daisy.dev.device-json-flat-dlq
+  normalization.statestore.cutoff.time.ms = 1800000 # 30 minutes
   state.store.name = daisy.dev.device-counters-store
   state.store.max.counter.cache.age = 10000
   state.store.int.counter.wrap.limit = 10000

--- a/candyfloss/src/test/resources/counter-normalization/application-seconds.conf
+++ b/candyfloss/src/test/resources/counter-normalization/application-seconds.conf
@@ -13,6 +13,7 @@ kstream {
   input.topic.name = daisy.prod.device-json-raw
   discard.topic.name = daisy.dev.device-json-flat
   dlq.topic.name = daisy.dev.device-json-flat-dlq
+  normalization.statestore.cutoff.time.ms = 1800000 # 30 minutes
   state.store.name = daisy.dev.device-counters-store
   state.store.max.counter.cache.age = 10000
   state.store.int.counter.wrap.limit = 10000

--- a/candyfloss/src/test/resources/counter-normalization/application.conf
+++ b/candyfloss/src/test/resources/counter-normalization/application.conf
@@ -13,6 +13,7 @@ kstream {
   input.topic.name = daisy.prod.device-json-raw
   discard.topic.name = daisy.dev.device-json-flat
   dlq.topic.name = daisy.dev.device-json-flat-dlq
+  normalization.statestore.cutoff.time.ms = 1800000 # 30 minutes
   state.store.name = daisy.dev.device-counters-store
   state.store.max.counter.cache.age = 10000
   state.store.int.counter.wrap.limit = 10000

--- a/candyfloss/src/test/resources/counter-normalization/older/input3.json
+++ b/candyfloss/src/test/resources/counter-normalization/older/input3.json
@@ -1,0 +1,32 @@
+{
+  "msg_metadata": {
+    "event_type": "dump",
+    "seq": 21196988,
+    "milli-timestamp": 1647244800004,
+    "telemetry_node": "192.168.1.22",
+    "telemetry_port": 55286,
+    "serialization": "gpb",
+    "writer_id": "daisy64stcisco1v01c/2080144",
+    "label": {
+      "nkey": "unknown",
+      "pkey": "unknown"
+    }
+  },
+  "telemetry_metadata": {
+    "collection_id": 910867,
+    "collection_end_time": 1647244767814,
+    "collection_start_time": 0,
+    "encoding_path": "openconfig-interfaces:interfaces",
+    "subscription": "DAISY-SUBSCRIPTION",
+    "msg_timestamp": 1647244767813,
+    "node_id": "hoa01ro1010zoi"
+  },
+  "timestamp": 1647244767278,
+  "name": "TenGigE0/0/0/0",
+  "state": {
+    "u64-counter": 3300,
+    "u32-counter": 330,
+    "u32-value": 22,
+    "u64-value": 11
+  }
+}

--- a/candyfloss/src/test/resources/counter-normalization/older/input4.json
+++ b/candyfloss/src/test/resources/counter-normalization/older/input4.json
@@ -1,0 +1,32 @@
+{
+  "msg_metadata": {
+    "event_type": "dump",
+    "seq": 21196988,
+    "milli-timestamp": 32498808463000,
+    "telemetry_node": "192.168.1.22",
+    "telemetry_port": 55286,
+    "serialization": "gpb",
+    "writer_id": "daisy64stcisco1v01c/2080144",
+    "label": {
+      "nkey": "unknown",
+      "pkey": "unknown"
+    }
+  },
+  "telemetry_metadata": {
+    "collection_id": 910867,
+    "collection_end_time": 1647244767814,
+    "collection_start_time": 0,
+    "encoding_path": "openconfig-interfaces:interfaces",
+    "subscription": "DAISY-SUBSCRIPTION",
+    "msg_timestamp": 1647244767813,
+    "node_id": "hoa01ro1010zoi"
+  },
+  "timestamp": 1647244767278,
+  "name": "TenGigE0/0/0/0",
+  "state": {
+    "u64-counter": 3800,
+    "u32-counter": 380,
+    "u32-value": 28,
+    "u64-value": 18
+  }
+}

--- a/candyfloss/src/test/resources/counter-normalization/older/input5.json
+++ b/candyfloss/src/test/resources/counter-normalization/older/input5.json
@@ -1,0 +1,32 @@
+{
+  "msg_metadata": {
+    "event_type": "dump",
+    "seq": 21196988,
+    "milli-timestamp": 1647244810011,
+    "telemetry_node": "192.168.1.22",
+    "telemetry_port": 55286,
+    "serialization": "gpb",
+    "writer_id": "daisy64stcisco1v01c/2080144",
+    "label": {
+      "nkey": "unknown",
+      "pkey": "unknown"
+    }
+  },
+  "telemetry_metadata": {
+    "collection_id": 910867,
+    "collection_end_time": 1647244800008,
+    "collection_start_time": 0,
+    "encoding_path": "openconfig-interfaces:interfaces",
+    "subscription": "DAISY-SUBSCRIPTION",
+    "msg_timestamp": 1647244767813,
+    "node_id": "hoa01ro1010zoi"
+  },
+  "timestamp": 1647244800008,
+  "name": "TenGigE0/0/0/0",
+  "state": {
+    "u64-counter": 3810,
+    "u32-counter": 383,
+    "u32-value": 28,
+    "u64-value": 18
+  }
+}

--- a/candyfloss/src/test/resources/counter-normalization/older/input6.json
+++ b/candyfloss/src/test/resources/counter-normalization/older/input6.json
@@ -1,0 +1,32 @@
+{
+  "msg_metadata": {
+    "event_type": "dump",
+    "seq": 21196988,
+    "milli-timestamp": 1647244810021,
+    "telemetry_node": "192.168.1.22",
+    "telemetry_port": 55286,
+    "serialization": "gpb",
+    "writer_id": "daisy64stcisco1v01c/2080144",
+    "label": {
+      "nkey": "unknown",
+      "pkey": "unknown"
+    }
+  },
+  "telemetry_metadata": {
+    "collection_id": 910867,
+    "collection_end_time": 1647244800008,
+    "collection_start_time": 0,
+    "encoding_path": "openconfig-interfaces:interfaces",
+    "subscription": "DAISY-SUBSCRIPTION",
+    "msg_timestamp": 1647244767813,
+    "node_id": "hoa01ro1010zoi"
+  },
+  "timestamp": 1647244800008,
+  "name": "TenGigE0/0/0/0",
+  "state": {
+    "u64-counter": 3820,
+    "u32-counter": 384,
+    "u32-value": 28,
+    "u64-value": 18
+  }
+}

--- a/candyfloss/src/test/resources/counter-normalization/older/input7.json
+++ b/candyfloss/src/test/resources/counter-normalization/older/input7.json
@@ -1,0 +1,32 @@
+{
+  "msg_metadata": {
+    "event_type": "dump",
+    "seq": 21196988,
+    "milli-timestamp": 1647244810031,
+    "telemetry_node": "192.168.1.22",
+    "telemetry_port": 55286,
+    "serialization": "gpb",
+    "writer_id": "daisy64stcisco1v01c/2080144",
+    "label": {
+      "nkey": "unknown",
+      "pkey": "unknown"
+    }
+  },
+  "telemetry_metadata": {
+    "collection_id": 910867,
+    "collection_end_time": 1647244800008,
+    "collection_start_time": 0,
+    "encoding_path": "openconfig-interfaces:interfaces",
+    "subscription": "DAISY-SUBSCRIPTION",
+    "msg_timestamp": 1647244767813,
+    "node_id": "hoa01ro1010zoi"
+  },
+  "timestamp": 1647244800008,
+  "name": "TenGigE0/0/0/0",
+  "state": {
+    "u64-counter": 3830,
+    "u32-counter": 387,
+    "u32-value": 28,
+    "u64-value": 18
+  }
+}

--- a/candyfloss/src/test/resources/counter-normalization/older/output3.json
+++ b/candyfloss/src/test/resources/counter-normalization/older/output3.json
@@ -1,0 +1,32 @@
+{
+  "msg_metadata": {
+    "event_type": "dump",
+    "seq": 21196988,
+    "milli-timestamp": 1647244800004,
+    "telemetry_node": "192.168.1.22",
+    "telemetry_port": 55286,
+    "serialization": "gpb",
+    "writer_id": "daisy64stcisco1v01c/2080144",
+    "label": {
+      "nkey": "unknown",
+      "pkey": "unknown"
+    }
+  },
+  "telemetry_metadata": {
+    "collection_id": 910867,
+    "collection_end_time": 1647244767814,
+    "collection_start_time": 0,
+    "encoding_path": "openconfig-interfaces:interfaces",
+    "subscription": "DAISY-SUBSCRIPTION",
+    "msg_timestamp": 1647244767813,
+    "node_id": "hoa01ro1010zoi"
+  },
+  "timestamp": 1647244767278,
+  "name": "TenGigE0/0/0/0",
+  "state": {
+    "u64-counter": 2300, // state is still from input 1
+    "u32-counter": 230,
+    "u32-value": 22,
+    "u64-value": 11
+  }
+}

--- a/candyfloss/src/test/resources/counter-normalization/older/output4.json
+++ b/candyfloss/src/test/resources/counter-normalization/older/output4.json
@@ -1,0 +1,32 @@
+{
+  "msg_metadata": {
+    "event_type": "dump",
+    "seq": 21196988,
+    "milli-timestamp": 32498808463000,
+    "telemetry_node": "192.168.1.22",
+    "telemetry_port": 55286,
+    "serialization": "gpb",
+    "writer_id": "daisy64stcisco1v01c/2080144",
+    "label": {
+      "nkey": "unknown",
+      "pkey": "unknown"
+    }
+  },
+  "telemetry_metadata": {
+    "collection_id": 910867,
+    "collection_end_time": 1647244767814,
+    "collection_start_time": 0,
+    "encoding_path": "openconfig-interfaces:interfaces",
+    "subscription": "DAISY-SUBSCRIPTION",
+    "msg_timestamp": 1647244767813,
+    "node_id": "hoa01ro1010zoi"
+  },
+  "timestamp": 1647244767278,
+  "name": "TenGigE0/0/0/0",
+  "state": {
+    "u64-counter": null, // we still do normal normalization (input4-input3), stateStore is by input4
+    "u32-counter": null,
+    "u32-value": 28, // this is Value directly from input4
+    "u64-value": 18
+  }
+}

--- a/candyfloss/src/test/resources/counter-normalization/older/output5.json
+++ b/candyfloss/src/test/resources/counter-normalization/older/output5.json
@@ -1,0 +1,32 @@
+{
+  "msg_metadata": {
+    "event_type": "dump",
+    "seq": 21196988,
+    "milli-timestamp": 1647244810011,
+    "telemetry_node": "192.168.1.22",
+    "telemetry_port": 55286,
+    "serialization": "gpb",
+    "writer_id": "daisy64stcisco1v01c/2080144",
+    "label": {
+      "nkey": "unknown",
+      "pkey": "unknown"
+    }
+  },
+  "telemetry_metadata": {
+    "collection_id": 910867,
+    "collection_end_time": 1647244800008,
+    "collection_start_time": 0,
+    "encoding_path": "openconfig-interfaces:interfaces",
+    "subscription": "DAISY-SUBSCRIPTION",
+    "msg_timestamp": 1647244767813,
+    "node_id": "hoa01ro1010zoi"
+  },
+  "timestamp": 1647244800008,
+  "name": "TenGigE0/0/0/0",
+  "state": {
+    "u64-counter": null, // due to state store is deleted
+    "u32-counter": null,
+    "u32-value": 28,
+    "u64-value": 18
+  }
+}

--- a/candyfloss/src/test/resources/counter-normalization/older/output6.json
+++ b/candyfloss/src/test/resources/counter-normalization/older/output6.json
@@ -1,0 +1,32 @@
+{
+  "msg_metadata": {
+    "event_type": "dump",
+    "seq": 21196988,
+    "milli-timestamp": 1647244810021,
+    "telemetry_node": "192.168.1.22",
+    "telemetry_port": 55286,
+    "serialization": "gpb",
+    "writer_id": "daisy64stcisco1v01c/2080144",
+    "label": {
+      "nkey": "unknown",
+      "pkey": "unknown"
+    }
+  },
+  "telemetry_metadata": {
+    "collection_id": 910867,
+    "collection_end_time": 1647244800008,
+    "collection_start_time": 0,
+    "encoding_path": "openconfig-interfaces:interfaces",
+    "subscription": "DAISY-SUBSCRIPTION",
+    "msg_timestamp": 1647244767813,
+    "node_id": "hoa01ro1010zoi"
+  },
+  "timestamp": 1647244800008,
+  "name": "TenGigE0/0/0/0",
+  "state": {
+    "u64-counter": null,
+    "u32-counter": null,
+    "u32-value": 28,
+    "u64-value": 18
+  }
+}

--- a/candyfloss/src/test/resources/counter-normalization/older/output7.json
+++ b/candyfloss/src/test/resources/counter-normalization/older/output7.json
@@ -1,0 +1,32 @@
+{
+  "msg_metadata": {
+    "event_type": "dump",
+    "seq": 21196988,
+    "milli-timestamp": 1647244810031,
+    "telemetry_node": "192.168.1.22",
+    "telemetry_port": 55286,
+    "serialization": "gpb",
+    "writer_id": "daisy64stcisco1v01c/2080144",
+    "label": {
+      "nkey": "unknown",
+      "pkey": "unknown"
+    }
+  },
+  "telemetry_metadata": {
+    "collection_id": 910867,
+    "collection_end_time": 1647244800008,
+    "collection_start_time": 0,
+    "encoding_path": "openconfig-interfaces:interfaces",
+    "subscription": "DAISY-SUBSCRIPTION",
+    "msg_timestamp": 1647244767813,
+    "node_id": "hoa01ro1010zoi"
+  },
+  "timestamp": 1647244800008,
+  "name": "TenGigE0/0/0/0",
+  "state": {
+    "u64-counter": 10,
+    "u32-counter": 3,
+    "u32-value": 28,
+    "u64-value": 18
+  }
+}

--- a/candyfloss/src/test/resources/transformers/application-multi-match.conf
+++ b/candyfloss/src/test/resources/transformers/application-multi-match.conf
@@ -12,6 +12,7 @@ kstream {
   input.topic.name = daisy.prod.device-json-raw
   discard.topic.name = daisy.dev.device-json-flat
   dlq.topic.name = daisy.dev.device-json-flat-dlq
+  normalization.statestore.cutoff.time.ms = 1800000 # 30 minutes
   state.store.name = daisy.dev.device-counters-store
   state.store.max.counter.cache.age = 1000
   state.store.int.counter.wrap.limit = 10000

--- a/candyfloss/src/test/resources/transformers/application-pre-transform.conf
+++ b/candyfloss/src/test/resources/transformers/application-pre-transform.conf
@@ -13,6 +13,7 @@ kstream {
   input.topic.name = daisy.prod.device-json-raw
   discard.topic.name = daisy.dev.device-json-flat
   dlq.topic.name = daisy.dev.device-json-flat-dlq
+  normalization.statestore.cutoff.time.ms = 1800000 # 30 minutes
   state.store.name = daisy.dev.device-counters-store
   state.store.max.counter.cache.age = 1000
   state.store.int.counter.wrap.limit = 10000

--- a/candyfloss/src/test/resources/transformers/application.conf
+++ b/candyfloss/src/test/resources/transformers/application.conf
@@ -13,6 +13,7 @@ kstream {
   input.topic.name = daisy.prod.device-json-raw
   discard.topic.name = daisy.dev.device-json-flat
   dlq.topic.name = daisy.dev.device-json-flat-dlq
+  normalization.statestore.cutoff.time.ms = 1800000 # 30 minutes
   state.store.name = daisy.dev.device-counters-store
   state.store.max.counter.cache.age = 1000
   state.store.int.counter.wrap.limit = 10000


### PR DESCRIPTION
This PR fix a case that when two consecutive messages arrived with extremely large reordered timestamp, we delete the stateStore and make normalisation for this given "key" starting from scratch.

This prevent a potential issue that when a message with far future timestamp arrives, it could prevent all follow-up correct timestamped messages' normalilzation.
